### PR TITLE
Require absolute path from bare-path global linkMapping early return

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10053,7 +10053,7 @@
     },
     "packages/astro-github-loader": {
       "name": "@larkiny/astro-github-loader",
-      "version": "0.11.3",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-app": "^8.1.1",

--- a/packages/astro-github-loader/package.json
+++ b/packages/astro-github-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@larkiny/astro-github-loader",
   "type": "module",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Load content from GitHub repositories into Astro content collections with asset management and content transformations",
   "keywords": [
     "astro",

--- a/packages/astro-github-loader/src/github.link-transform.ts
+++ b/packages/astro-github-loader/src/github.link-transform.ts
@@ -337,7 +337,7 @@ function transformLink(
         globalMappings,
         context,
       );
-      if (rawMapped !== linkPath + anchor) {
+      if (rawMapped !== linkPath + anchor && rawMapped.startsWith("/")) {
         return `[${linkText}](${rawMapped})`;
       }
     }


### PR DESCRIPTION
## Summary
- The bare-path pre-normalization early return now requires the mapped result to start with `/` (absolute path)
- Prevents generic global mappings like `.md`-stripping from hijacking multi-segment relative links (e.g., `types/subscription.md`) that should resolve via `normalizePath()` + `sourceToTargetMap`
- Adds regression test for multi-segment relative sibling references with `.md`-stripping global mappings
- Bumps version to 0.14.5

## Test plan
- [x] New test: `types/subscription.md#anchor` resolves via sourceToTargetMap to absolute URL
- [x] All existing bare-path, `./`, `../`, and sibling reference tests still pass
- [x] All 304 tests pass
- [x] `tsc --noEmit` clean